### PR TITLE
fix: correct favicon MIME type from image/x-icon to image/png

### DIFF
--- a/404.html
+++ b/404.html
@@ -12,7 +12,7 @@
     <meta name="robots" content="noindex">
 
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="assets/logo.png">
+    <link rel="icon" type="image/png" href="assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="assets/logo.png">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/blog.html
+++ b/blog.html
@@ -31,7 +31,7 @@
         <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
         
         <!-- Favicons -->
-        <link rel="icon" type="image/x-icon" href="assets/logo.png">
+        <link rel="icon" type="image/png" href="assets/logo.png">
         <link rel="apple-touch-icon" sizes="180x180" href="assets/logo.png">
         
         <!-- Schema.org JSON-LD Structured Data -->

--- a/blogs/01012025.html
+++ b/blogs/01012025.html
@@ -33,7 +33,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
 
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
 
     <!-- Schema.org -->

--- a/blogs/01172025.html
+++ b/blogs/01172025.html
@@ -32,7 +32,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
     
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
     
     <!-- Schema.org JSON-LD Structured Data -->

--- a/blogs/01202025.html
+++ b/blogs/01202025.html
@@ -32,7 +32,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
     
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
     
     <!-- Schema.org JSON-LD Structured Data -->

--- a/blogs/01252025.html
+++ b/blogs/01252025.html
@@ -32,7 +32,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
     
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
     
     <!-- Schema.org JSON-LD Structured Data -->

--- a/blogs/02212026.html
+++ b/blogs/02212026.html
@@ -28,7 +28,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
     
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/blogs/03212025.html
+++ b/blogs/03212025.html
@@ -32,7 +32,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
     
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
     
     <!-- Schema.org JSON-LD Structured Data -->

--- a/blogs/04222026.html
+++ b/blogs/04222026.html
@@ -28,7 +28,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
     
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/blogs/05292026.html
+++ b/blogs/05292026.html
@@ -33,7 +33,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
 
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
 
     <!-- Schema.org -->

--- a/blogs/08122025.html
+++ b/blogs/08122025.html
@@ -32,7 +32,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
     
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
     
     <!-- Schema.org JSON-LD Structured Data -->

--- a/blogs/09292025.html
+++ b/blogs/09292025.html
@@ -32,7 +32,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
     
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
     
     <!-- Schema.org JSON-LD Structured Data -->

--- a/blogs/09302025.html
+++ b/blogs/09302025.html
@@ -32,7 +32,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
     
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
     
     <!-- Schema.org JSON-LD Structured Data -->

--- a/blogs/10282025.html
+++ b/blogs/10282025.html
@@ -32,7 +32,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
     
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
     
     <!-- Schema.org JSON-LD Structured Data -->

--- a/blogs/11092025.html
+++ b/blogs/11092025.html
@@ -33,7 +33,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
     
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
     
     <!-- Schema.org JSON-LD Structured Data -->

--- a/blogs/12212025.html
+++ b/blogs/12212025.html
@@ -28,7 +28,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
     
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/blogs/12312024.html
+++ b/blogs/12312024.html
@@ -33,7 +33,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
 
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
 
     <!-- Schema.org -->

--- a/blogs/blank.html
+++ b/blogs/blank.html
@@ -32,7 +32,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
 
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
 
     <!-- Schema.org -->

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
     
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="assets/logo.png">
+    <link rel="icon" type="image/png" href="assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="assets/logo.png">
     <link rel="icon" type="image/png" sizes="32x32" href="assets/logo.png">
     <link rel="icon" type="image/png" sizes="16x16" href="assets/logo.png">

--- a/projects.html
+++ b/projects.html
@@ -31,7 +31,7 @@
     <meta name="twitter:image" content="https://project516.dev/assets/logo.png">
     
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="assets/logo.png">
+    <link rel="icon" type="image/png" href="assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="assets/logo.png">
     
     <!-- Schema.org JSON-LD Structured Data -->

--- a/projects/retroview.html
+++ b/projects/retroview.html
@@ -24,7 +24,7 @@
     <meta name="twitter:image" content="https://raw.githubusercontent.com/Project516/retroview/master/assets/screenshots/birchforest.png">
 
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
 
     <!-- Schema.org -->

--- a/projects/template.html
+++ b/projects/template.html
@@ -23,7 +23,7 @@
     <meta property="og:image" content="https://project516.dev/assets/logo.png">
 
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="../assets/logo.png">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/logo.png">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Problem

All HTML pages in the site declare the favicon with `type="image/x-icon"`, but the actual file (`assets/logo.png`) is a PNG image. Using the wrong MIME type can cause browsers to misidentify or reject the favicon entirely.

Interestingly, `index.html` already had two additional `<link rel="icon">` tags on lines 37–38 that correctly used `type="image/png"` — making the first tag on line 35 inconsistent with the rest.

## Fix

Replace `type="image/x-icon"` with `type="image/png"` on the `<link rel="icon">` element across all 22 HTML files:

- `index.html`
- `404.html`
- `blog.html`
- `projects.html`
- `projects/retroview.html`
- `projects/template.html`
- 17 blog posts under `blogs/`

## Testing

- All favicon `href` values still point to `assets/logo.png` (or `../assets/logo.png` for subdirectory pages) — no path changes.
- The `type` attribute now matches the actual file format.
- No visual or behavioral changes expected; this only ensures the MIME type hint is correct for browsers that rely on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated site favicon references across the main pages and blog/project pages to use the PNG icon type consistently.
  - This should help browsers display the site icon more reliably in tabs and bookmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->