### PR TITLE
Add Source on GitHub link to footer

### DIFF
--- a/404.html
+++ b/404.html
@@ -43,6 +43,7 @@
 
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
 
     <script src="script.js"></script>

--- a/blog.html
+++ b/blog.html
@@ -260,6 +260,7 @@
     </main>
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
     
     <script src="script.js"></script>

--- a/blogs/01012025.html
+++ b/blogs/01012025.html
@@ -75,6 +75,7 @@
 
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
 
     <script src="../script.js"></script>

--- a/blogs/01172025.html
+++ b/blogs/01172025.html
@@ -83,6 +83,7 @@
 
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
     
     <script src="../script.js"></script>

--- a/blogs/01202025.html
+++ b/blogs/01202025.html
@@ -105,6 +105,7 @@
     </main>
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
     <script src="../script.js"></script>
 </body>

--- a/blogs/01252025.html
+++ b/blogs/01252025.html
@@ -84,6 +84,7 @@
 
     <footer>
       <p>&copy; <span id="year">2026</span> project516</p>
+      <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
     <script src="../script.js"></script>
 </body>

--- a/blogs/02212026.html
+++ b/blogs/02212026.html
@@ -59,6 +59,7 @@
   
   <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
   </footer>
   
   <script src="../script.js"></script>

--- a/blogs/03212025.html
+++ b/blogs/03212025.html
@@ -87,6 +87,7 @@
 
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
     
     <script src="../script.js"></script>

--- a/blogs/04222026.html
+++ b/blogs/04222026.html
@@ -56,6 +56,7 @@
   
   <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
   </footer>
   
   <script src="../script.js"></script>

--- a/blogs/05292026.html
+++ b/blogs/05292026.html
@@ -76,6 +76,7 @@
 
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
 
     <script src="../script.js"></script>

--- a/blogs/08122025.html
+++ b/blogs/08122025.html
@@ -83,6 +83,7 @@
 
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
 </body>
 </html>

--- a/blogs/09292025.html
+++ b/blogs/09292025.html
@@ -86,6 +86,7 @@
 
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
     
     <script src="../script.js"></script>

--- a/blogs/09302025.html
+++ b/blogs/09302025.html
@@ -85,6 +85,7 @@
 
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
     
     <script src="../script.js"></script>

--- a/blogs/10282025.html
+++ b/blogs/10282025.html
@@ -85,6 +85,7 @@
     
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
 </body>
 </html>

--- a/blogs/11092025.html
+++ b/blogs/11092025.html
@@ -86,6 +86,7 @@
 
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
     
     <script src="../script.js"></script>

--- a/blogs/12212025.html
+++ b/blogs/12212025.html
@@ -57,6 +57,7 @@
   
   <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
   </footer>
   
   <script src="../script.js"></script>

--- a/blogs/12312024.html
+++ b/blogs/12312024.html
@@ -76,6 +76,7 @@
 
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
 
     <script src="../script.js"></script>

--- a/blogs/blank.html
+++ b/blogs/blank.html
@@ -74,6 +74,7 @@
 
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
 
     <script src="../script.js"></script>

--- a/index.html
+++ b/index.html
@@ -119,6 +119,7 @@
 
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
     
     <script src="script.js"></script>

--- a/projects.html
+++ b/projects.html
@@ -133,6 +133,7 @@
     
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
     
     <script src="script.js"></script>

--- a/projects/retroview.html
+++ b/projects/retroview.html
@@ -109,6 +109,7 @@
 
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
 
     <script src="../script.js"></script>

--- a/projects/template.html
+++ b/projects/template.html
@@ -84,6 +84,7 @@
 
     <footer>
         <p>&copy; <span id="year">2026</span> project516</p>
+        <p class="footer-source-link"><a href="https://github.com/Project516/project516.github.io" target="_blank" rel="noopener noreferrer">Source on GitHub</a></p>
     </footer>
 
     <script src="../script.js"></script>

--- a/style.css
+++ b/style.css
@@ -689,6 +689,16 @@ footer {
   margin-left: var(--sidebar-width);
 }
 
+footer p {
+  margin-bottom: 0.5rem;
+}
+
+footer .footer-source-link {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  margin-bottom: 0;
+}
+
 @media (prefers-reduced-motion: no-preference) {
   section[data-animate] {
     opacity: 0;


### PR DESCRIPTION
On behalf of @project516

This change adds a 'Source on GitHub' link to the footer of all pages in the site, addressing issue #31 'Link back to this repo'.

Changes:
- Added footer source link to index.html, projects.html, blog.html, 404.html
- Added footer source link to all blog posts in /blogs/
- Added footer source link to project pages in /projects/
- Added CSS styling for the footer links in style.css

The link points to https://github.com/Project516/project516.github.io and opens in a new tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added “Source on GitHub” links to the homepage, blog pages, project pages, and 404 page.
  - Links open securely in a new browser tab where applicable.

- **Style**
  - Added consistent footer styling for source links, including compact spacing, typography, and layout adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->