### PR TITLE
SEO enrichment for retroview project page

### DIFF
--- a/projects/retroview.html
+++ b/projects/retroview.html
@@ -21,6 +21,9 @@
     <meta property="og:site_name" content="project516">
     <meta property="og:image" content="https://raw.githubusercontent.com/Project516/retroview/master/assets/screenshots/birchforest.png">
     <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://project516.dev/projects/retroview.html">
+    <meta name="twitter:title" content="retroview -- Retro Minecraft Shader by project516">
+    <meta name="twitter:description" content="A Minecraft GLSL shader with a retro visual style. 19,000+ downloads on Modrinth and CurseForge.">
     <meta name="twitter:image" content="https://raw.githubusercontent.com/Project516/retroview/master/assets/screenshots/birchforest.png">
 
     <!-- Favicons -->
@@ -34,9 +37,36 @@
       "@type": "SoftwareApplication",
       "name": "retroview",
       "url": "https://project516.dev/projects/retroview.html",
+      "image": "https://raw.githubusercontent.com/Project516/retroview/master/assets/screenshots/birchforest.png",
       "author": { "@type": "Person", "name": "project516" },
-      "description": "A Minecraft GLSL shader with a retro visual style.",
-      "applicationCategory": "Game modification"
+      "description": "A Minecraft GLSL shader with a retro visual style. 19,000+ downloads on Modrinth and CurseForge.",
+      "applicationCategory": "Game modification",
+      "operatingSystem": "Cross-platform (Minecraft Java Edition via OptiFine/Iris)",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Projects",
+          "item": "https://project516.dev/projects.html"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "retroview",
+          "item": "https://project516.dev/projects/retroview.html"
+        }
+      ]
     }
     </script>
 


### PR DESCRIPTION
On behalf of @project516

Aligns SEO on the retroview project page with the same standards used on blog posts:

- Add missing Twitter Card tags (twitter:url, twitter:title, twitter:description) to enable rich previews on X/Twitter.
- Enrich the SoftwareApplication JSON-LD with image, operatingSystem, and free Offer for proper rich results.
- Add a BreadcrumbList JSON-LD matching the breadcrumb navigation.

Addresses the open issue #54 "Add more SEO".

seo(projects): enrich retroview page structured data and Twitter Card

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced social media preview metadata for the Retroview project page.
  * Expanded structured data with application details, author information, pricing, and supported operating system.
  * Added breadcrumb metadata to improve page navigation visibility in search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->